### PR TITLE
Implement Linux support using `lslocks`. (fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ List all processes that have a lock on a file. This doesn't work with directorie
 # Supported OS
 
 * Windows
-
+* Linux (util-linux v2.27+)

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,10 +5,6 @@
             "includes": [
                 "auto.gypi"
             ],
-            "sources": [
-                "src_win/impl.cpp",
-                "src_win/wholocks.cpp"
-            ],
             "include_dirs": [
             ],
             "libraries": [
@@ -23,7 +19,15 @@
                 "VCCLCompilerTool": {
                     "ExceptionHandling": 1
                 }
-            }
+            },
+            "conditions":  [
+                ["OS=='win'", {
+                    "sources": [
+                        "src_win/impl.cpp",
+                        "src_win/wholocks.cpp"
+                    ]
+                }]
+            ]
         }
     ],
     "includes": [

--- a/index.js
+++ b/index.js
@@ -1,13 +1,24 @@
+const { execFileSync } = require('child_process');
 const path = require('path');
 
+function linuxGetLocks(checkPath) {
+  const { locks } = JSON.parse(execFileSync('lslocks', ['-J']));
+  return locks
+    .filter(lock => lock.path === checkPath)
+    .map(lock => ({ appName: lock.command, pid: lock.pid }));
+}
+
 function wholocks(checkPath) {
-    if (process.platform === 'win32') {
-      let lib = require('./build/Release/wholocks');
-      return lib.wholocks(path.normalize(checkPath));
-    } // not implemented on other platforms yet
+  if (process.platform === 'win32') {
+    const lib = require('./build/Release/wholocks');
+    return lib.wholocks(path.normalize(checkPath));
+  } else if (process.platform === 'linux') {
+    return linuxGetLocks(path.normalize(checkPath));
+  } else {
+    throw new Error('Platform not supported');
   }
-  
-  module.exports = {
-    default: wholocks,
-  }
-  
+}
+
+module.exports = {
+  default: wholocks,
+};

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { execFileSync } = require('child_process');
 const path = require('path');
 
 function linuxGetLocks(checkPath) {
-  const { locks } = JSON.parse(execFileSync('lslocks', ['-J']));
+  const { locks } = JSON.parse(execFileSync('lslocks', ['-o', 'command,pid,path', '-J']));
   return locks
     .filter(lock => lock.path === checkPath)
     .map(lock => ({ appName: lock.command, pid: lock.pid }));


### PR DESCRIPTION
lslocks has a handy switch (`-J`) that spits out all the locks in JSON format which works just perfectly with Node :)

Fixes #1